### PR TITLE
Added optional feature mem-dbg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_borsh = ["borsh", "serde"]
 ahash = "0.8"
 serde = { version = "^1.0", features = ["derive"], optional = true}
 borsh = { version = "1.2.1", features = ["derive"], optional = true}
+mem_dbg = { version="0.2.4", optional = true }
 
 
 [dev-dependencies]

--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -26,6 +26,7 @@ const SEED: RandomState = RandomState::with_seeds(
 /// Q = 64 - P
 /// Register num is 1 << P
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct HyperLogLog<const P: usize = DEFAULT_P> {
     pub(crate) registers: Vec<u8>,
 }


### PR DESCRIPTION
As per the title, I have added [mem_dbg](https://crates.io/crates/mem_dbg) as an optional feature to make it easy to compare the memory requirements of this library with others.

Cheers!

Luca