### PR TITLE
Created generic for hashers

### DIFF
--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -16,7 +16,7 @@ const DEFAULT_P: usize = 14_usize;
 /// P is the bucket number, must be [4, 18]
 /// Q = 64 - P
 /// Register num is 1 << P
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct HyperLogLog<H = AHasher, const P: usize = DEFAULT_P> {
     pub(crate) registers: Vec<u8>,
@@ -28,6 +28,14 @@ impl<H: Default + Hasher, const P: usize> Default for HyperLogLog<H, P> {
         Self::new()
     }
 }
+
+impl<H, const P: usize> PartialEq for HyperLogLog<H, P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.registers == other.registers
+    }
+}
+
+impl<H, const P: usize> Eq for HyperLogLog<H, P> {}
 
 impl<H: Default + Hasher, const P: usize> HyperLogLog<H, P> {
     /// note that this method should not be invoked in untrusted environment

--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -12,7 +12,7 @@ use std::hash::{Hash, Hasher};
 const DEFAULT_P: usize = 14_usize;
 
 /// HyperLogLog is a probabilistic data structure used to estimate the cardinality of a multiset.
-/// 
+///
 /// Note: We don't make HyperLogLog as static struct by keeping `PhantomData<T>`
 /// Callers should take care of its hash function to be unchanged.
 /// P is the bucket number, must be [4, 18]

--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -11,6 +11,8 @@ use std::hash::{Hash, Hasher};
 /// By default, we use 2**14 registers like redis
 const DEFAULT_P: usize = 14_usize;
 
+/// HyperLogLog is a probabilistic data structure used to estimate the cardinality of a multiset.
+/// 
 /// Note: We don't make HyperLogLog as static struct by keeping `PhantomData<T>`
 /// Callers should take care of its hash function to be unchanged.
 /// P is the bucket number, must be [4, 18]

--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -5,8 +5,8 @@
 //! 1. https://github.com/crepererum/pdatastructs.rs/blob/3997ed50f6b6871c9e53c4c5e0f48f431405fc63/src/hyperloglog.rs
 //! 2. https://github.com/apache/arrow-datafusion/blob/f203d863f5c8bc9f133f6dd9b2e34e57ac3cdddc/datafusion/physical-expr/src/aggregate/hyperloglog.rs
 
-use std::hash::{Hash, Hasher};
 use ahash::AHasher;
+use std::hash::{Hash, Hasher};
 
 /// By default, we use 2**14 registers like redis
 const DEFAULT_P: usize = 14_usize;
@@ -18,12 +18,12 @@ const DEFAULT_P: usize = 14_usize;
 /// Register num is 1 << P
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
-pub struct HyperLogLog<H=AHasher, const P: usize = DEFAULT_P> {
+pub struct HyperLogLog<H = AHasher, const P: usize = DEFAULT_P> {
     pub(crate) registers: Vec<u8>,
     _hasher: std::marker::PhantomData<H>,
 }
 
-impl<H:  Default + Hasher, const P: usize> Default for HyperLogLog<H, P> {
+impl<H: Default + Hasher, const P: usize> Default for HyperLogLog<H, P> {
     fn default() -> Self {
         Self::new()
     }
@@ -47,7 +47,10 @@ impl<H: Default + Hasher, const P: usize> HyperLogLog<H, P> {
     pub fn with_registers(registers: Vec<u8>) -> Self {
         assert_eq!(registers.len(), Self::number_registers());
 
-        Self { registers, _hasher: std::marker::PhantomData }
+        Self {
+            registers,
+            _hasher: std::marker::PhantomData,
+        }
     }
 
     /// Adds an hash to the HyperLogLog.

--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -18,12 +18,12 @@ const DEFAULT_P: usize = 14_usize;
 /// Register num is 1 << P
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
-pub struct HyperLogLog<H, const P: usize = DEFAULT_P> {
+pub struct HyperLogLog<H=AHasher, const P: usize = DEFAULT_P> {
     pub(crate) registers: Vec<u8>,
     _hasher: std::marker::PhantomData<H>,
 }
 
-impl<const P: usize> Default for HyperLogLog<AHasher, P> {
+impl<H:  Default + Hasher, const P: usize> Default for HyperLogLog<H, P> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -101,11 +101,12 @@ impl<H: Default + Hasher, const P: usize> borsh::BorshDeserialize for HyperLogLo
 #[cfg(test)]
 mod tests {
     use crate::HyperLogLog;
+    use ahash::AHasher;
 
     const P: usize = 14;
     #[test]
     fn test_serde() {
-        let mut hll = HyperLogLog::<H, P>::new();
+        let mut hll = HyperLogLog::<AHasher, P>::new();
         json_serde_equal(&hll);
 
         for i in 0..100000 {
@@ -113,7 +114,7 @@ mod tests {
         }
         json_serde_equal(&hll);
 
-        let hll = HyperLogLog::<H, P>::with_registers(vec![1; 1 << P]);
+        let hll = HyperLogLog::<AHasher, P>::with_registers(vec![1; 1 << P]);
         json_serde_equal(&hll);
     }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,4 +1,5 @@
 use crate::HyperLogLog;
+use core::hash::Hasher;
 
 #[derive(serde::Serialize, borsh::BorshSerialize)]
 enum HyperLogLogVariantRef<'a, const P: usize> {
@@ -14,30 +15,33 @@ enum HyperLogLogVariant<const P: usize> {
     Full(Vec<u8>),
 }
 
-impl<const P: usize> From<HyperLogLogVariant<P>> for HyperLogLog<P> {
+impl<H: Default + Hasher, const P: usize> From<HyperLogLogVariant<P>> for HyperLogLog<H, P> {
     fn from(value: HyperLogLogVariant<P>) -> Self {
         match value {
-            HyperLogLogVariant::Empty => HyperLogLog::<P>::new(),
+            HyperLogLogVariant::Empty => Self::new(),
             HyperLogLogVariant::Sparse { data } => {
                 let mut registers = vec![0; 1 << P];
                 for (index, val) in data {
                     registers[index as usize] = val;
                 }
 
-                HyperLogLog::<P> { registers }
+                Self::with_registers(registers)
             }
-            HyperLogLogVariant::Full(registers) => HyperLogLog::<P> { registers },
+            HyperLogLogVariant::Full(registers) => Self::with_registers(registers),
         }
     }
 }
 
-impl<'a, const P: usize> From<&'a HyperLogLog<P>> for HyperLogLogVariantRef<'a, P> {
-    fn from(hll: &'a HyperLogLog<P>) -> Self {
-        let none_empty_registers = HyperLogLog::<P>::number_registers() - hll.num_empty_registers();
+impl<'a, H: Default + Hasher, const P: usize> From<&'a HyperLogLog<H, P>>
+    for HyperLogLogVariantRef<'a, P>
+{
+    fn from(hll: &'a HyperLogLog<H, P>) -> Self {
+        let none_empty_registers =
+            HyperLogLog::<H, P>::number_registers() - hll.num_empty_registers();
 
         if none_empty_registers == 0 {
             HyperLogLogVariantRef::Empty
-        } else if none_empty_registers * 3 <= HyperLogLog::<P>::number_registers() {
+        } else if none_empty_registers * 3 <= HyperLogLog::<H, P>::number_registers() {
             // If the number of empty registers is larger enough, we can use sparse serialize to reduce the binary size
             // each register in sparse format will occupy 3 bytes, 2 for register index and 1 for register value.
             let sparse_data: Vec<(u16, u8)> = hll
@@ -60,7 +64,7 @@ impl<'a, const P: usize> From<&'a HyperLogLog<P>> for HyperLogLogVariantRef<'a, 
     }
 }
 
-impl<const P: usize> serde::Serialize for HyperLogLog<P> {
+impl<H: Default + Hasher, const P: usize> serde::Serialize for HyperLogLog<H, P> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -70,7 +74,7 @@ impl<const P: usize> serde::Serialize for HyperLogLog<P> {
     }
 }
 
-impl<'de, const P: usize> serde::Deserialize<'de> for HyperLogLog<P> {
+impl<'de, H: Default + Hasher, const P: usize> serde::Deserialize<'de> for HyperLogLog<H, P> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -80,14 +84,14 @@ impl<'de, const P: usize> serde::Deserialize<'de> for HyperLogLog<P> {
     }
 }
 
-impl<const P: usize> borsh::BorshSerialize for HyperLogLog<P> {
+impl<H: Default + Hasher, const P: usize> borsh::BorshSerialize for HyperLogLog<H, P> {
     fn serialize<W: std::io::prelude::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         let v: HyperLogLogVariantRef<'_, P> = self.into();
         v.serialize(writer)
     }
 }
 
-impl<const P: usize> borsh::BorshDeserialize for HyperLogLog<P> {
+impl<H: Default + Hasher, const P: usize> borsh::BorshDeserialize for HyperLogLog<H, P> {
     fn deserialize_reader<R: std::io::prelude::Read>(reader: &mut R) -> std::io::Result<Self> {
         let v = HyperLogLogVariant::<P>::deserialize_reader(reader)?;
         Ok(v.into())
@@ -101,7 +105,7 @@ mod tests {
     const P: usize = 14;
     #[test]
     fn test_serde() {
-        let mut hll = HyperLogLog::<P>::new();
+        let mut hll = HyperLogLog::<H, P>::new();
         json_serde_equal(&hll);
 
         for i in 0..100000 {
@@ -109,7 +113,7 @@ mod tests {
         }
         json_serde_equal(&hll);
 
-        let hll = HyperLogLog::<P>::with_registers(vec![1; 1 << P]);
+        let hll = HyperLogLog::<H, P>::with_registers(vec![1; 1 << P]);
         json_serde_equal(&hll);
     }
 


### PR DESCRIPTION
This addresses issue #2, introducing a generic for arbitrary hashers. The default remains as before a seeded AHasher, but using the Default seeds from the library itself.