### PR TITLE
feat: add custom hasher trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/sundy-li/simple_hll"
 edition = "2021"
 license = "Apache-2.0"
 name = "simple_hll"
-version = "0.0.1"
+version = "0.0.2"
 
 
 [features]
@@ -23,3 +23,4 @@ mem_dbg = { version="0.2.4", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
+xxhash-rust = {version = "0.8.0", features  = ["xxh3"] }

--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -326,16 +326,13 @@ mod tests {
 
     #[test]
     fn test_xxhash_hll() {
-        use std::hash::{BuildHasher, Hash, Hasher};
+        use std::hash::{BuildHasher, Hash};
         #[derive(Default)]
         struct XXH3;
         impl crate::Hasher for XXH3 {
             fn hll_hash<T: Hash>(x: T) -> u64 {
                 let builder = xxhash_rust::xxh3::Xxh3Builder::default();
-                let mut hasher = builder.build_hasher();
-
-                x.hash(&mut hasher);
-                hasher.finish()
+                builder.hash_one(x)
             }
         }
 
@@ -346,10 +343,7 @@ mod tests {
         impl crate::Hasher for XXH3WithSeed {
             fn hll_hash<T: Hash>(x: T) -> u64 {
                 let builder = xxhash_rust::xxh3::Xxh3Builder::default().with_seed(SEED);
-                let mut hasher = builder.build_hasher();
-
-                x.hash(&mut hasher);
-                hasher.finish()
+                builder.hash_one(x)
             }
         }
 

--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -5,7 +5,7 @@
 //! 1. https://github.com/crepererum/pdatastructs.rs/blob/3997ed50f6b6871c9e53c4c5e0f48f431405fc63/src/hyperloglog.rs
 //! 2. https://github.com/apache/arrow-datafusion/blob/f203d863f5c8bc9f133f6dd9b2e34e57ac3cdddc/datafusion/physical-expr/src/aggregate/hyperloglog.rs
 
-use std::hash::Hash;
+use core::hash::Hash;
 
 use ahash::AHasher;
 
@@ -23,7 +23,7 @@ const DEFAULT_P: usize = 14_usize;
 #[cfg_attr(feature = "mem_dbg", derive(mem_dbg::MemSize, mem_dbg::MemDbg))]
 pub struct HyperLogLog<H: Hasher = AHasher, const P: usize = DEFAULT_P> {
     pub(crate) registers: Vec<u8>,
-    _hasher: std::marker::PhantomData<H>,
+    _hasher: core::marker::PhantomData<H>,
 }
 
 impl<H: Hasher + Default, const P: usize> Default for HyperLogLog<H, P> {
@@ -43,7 +43,7 @@ impl<H: Hasher + Default, const P: usize> HyperLogLog<H, P> {
 
         Self {
             registers: vec![0; 1 << P],
-            _hasher: std::marker::PhantomData,
+            _hasher: core::marker::PhantomData,
         }
     }
 
@@ -52,7 +52,7 @@ impl<H: Hasher + Default, const P: usize> HyperLogLog<H, P> {
 
         Self {
             registers,
-            _hasher: std::marker::PhantomData,
+            _hasher: core::marker::PhantomData,
         }
     }
 
@@ -326,7 +326,7 @@ mod tests {
 
     #[test]
     fn test_xxhash_hll() {
-        use std::hash::{BuildHasher, Hash};
+        use core::hash::{BuildHasher, Hash};
         #[derive(Default)]
         struct XXH3;
         impl crate::Hasher for XXH3 {

--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -19,7 +19,7 @@ const DEFAULT_P: usize = 14_usize;
 /// P is the bucket number, must be [4, 18]
 /// Q = 64 - P
 /// Register num is 1 << P
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct HyperLogLog<H: Hasher = AHasher, const P: usize = DEFAULT_P> {
     pub(crate) registers: Vec<u8>,
     _hasher: core::marker::PhantomData<H>,
@@ -30,6 +30,14 @@ impl<H: Hasher + Default, const P: usize> Default for HyperLogLog<H, P> {
         Self::new()
     }
 }
+
+impl<H: Hasher + Default, const P: usize> PartialEq for HyperLogLog<H, P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.registers == other.registers
+    }
+}
+
+impl<H: Hasher + Default, const P: usize> Eq for HyperLogLog<H, P> {}
 
 impl<H: Hasher + Default, const P: usize> HyperLogLog<H, P> {
     /// note that this method should not be invoked in untrusted environment

--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -68,7 +68,7 @@ impl<H: Hasher + Default, const P: usize> HyperLogLog<H, P> {
     /// Adds an object to the HyperLogLog.
     /// Though we could pass different types into this method, caller should notice that
     pub fn add_object<T: Hash>(&mut self, obj: &T) {
-        let hash = H::hash_one(obj);
+        let hash = H::hll_hash(obj);
         self.add_hash(hash);
     }
 
@@ -330,7 +330,7 @@ mod tests {
         #[derive(Default)]
         struct XXH3;
         impl crate::Hasher for XXH3 {
-            fn hash_one<T: Hash>(x: T) -> u64 {
+            fn hll_hash<T: Hash>(x: T) -> u64 {
                 let builder = xxhash_rust::xxh3::Xxh3Builder::default();
                 let mut hasher = builder.build_hasher();
 
@@ -344,7 +344,7 @@ mod tests {
         const SEED: u64 = 0x1234_5678_u64;
 
         impl crate::Hasher for XXH3WithSeed {
-            fn hash_one<T: Hash>(x: T) -> u64 {
+            fn hll_hash<T: Hash>(x: T) -> u64 {
                 let builder = xxhash_rust::xxh3::Xxh3Builder::default().with_seed(SEED);
                 let mut hasher = builder.build_hasher();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,26 @@ mod hyperloglog;
 #[cfg(feature = "serde_borsh")]
 mod serde;
 
+use ahash::RandomState;
 pub use hyperloglog::HyperLogLog;
+
+use core::hash::Hash;
+pub trait Hasher {
+    fn hash_one<T: Hash>(x: T) -> u64
+    where
+        Self: Sized;
+}
+
+/// Fixed seed
+const SEED: RandomState = RandomState::with_seeds(
+    0x355e438b4b1478c7_u64,
+    0xd0e8453cd135b473_u64,
+    0xf7b252066a57836a_u64,
+    0xb8a829e3713c09bf_u64,
+);
+
+impl Hasher for ahash::AHasher {
+    fn hash_one<T: Hash>(x: T) -> u64 {
+        SEED.hash_one(x)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ pub use hyperloglog::HyperLogLog;
 
 use core::hash::Hash;
 pub trait Hasher {
-    fn hash_one<T: Hash>(x: T) -> u64
+    fn hll_hash<T: Hash>(x: T) -> u64
     where
         Self: Sized;
 }
@@ -22,7 +22,7 @@ const SEED: RandomState = RandomState::with_seeds(
 );
 
 impl Hasher for ahash::AHasher {
-    fn hash_one<T: Hash>(x: T) -> u64 {
+    fn hll_hash<T: Hash>(x: T) -> u64 {
         SEED.hash_one(x)
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -81,14 +81,14 @@ impl<'de, const P: usize> serde::Deserialize<'de> for HyperLogLog<P> {
 }
 
 impl<const P: usize> borsh::BorshSerialize for HyperLogLog<P> {
-    fn serialize<W: std::io::prelude::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+    fn serialize<W: core::io::prelude::Write>(&self, writer: &mut W) -> core::io::Result<()> {
         let v: HyperLogLogVariantRef<'_, P> = self.into();
         v.serialize(writer)
     }
 }
 
 impl<const P: usize> borsh::BorshDeserialize for HyperLogLog<P> {
-    fn deserialize_reader<R: std::io::prelude::Read>(reader: &mut R) -> std::io::Result<Self> {
+    fn deserialize_reader<R: core::io::prelude::Read>(reader: &mut R) -> core::io::Result<Self> {
         let v = HyperLogLogVariant::<P>::deserialize_reader(reader)?;
         Ok(v.into())
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,43 +1,46 @@
-use crate::HyperLogLog;
+use crate::{Hasher, HyperLogLog};
 
 #[derive(serde::Serialize, borsh::BorshSerialize)]
-enum HyperLogLogVariantRef<'a, const P: usize> {
+enum HyperLogLogVariantRef<'a> {
     Empty,
     Sparse { data: Vec<(u16, u8)> },
     Full(&'a Vec<u8>),
 }
 
 #[derive(serde::Deserialize, borsh::BorshDeserialize)]
-enum HyperLogLogVariant<const P: usize> {
+enum HyperLogLogVariant {
     Empty,
     Sparse { data: Vec<(u16, u8)> },
     Full(Vec<u8>),
 }
 
-impl<const P: usize> From<HyperLogLogVariant<P>> for HyperLogLog<P> {
-    fn from(value: HyperLogLogVariant<P>) -> Self {
+impl<H: Hasher + Default, const P: usize> From<HyperLogLogVariant> for HyperLogLog<H, P> {
+    fn from(value: HyperLogLogVariant) -> Self {
         match value {
-            HyperLogLogVariant::Empty => HyperLogLog::<P>::new(),
+            HyperLogLogVariant::Empty => HyperLogLog::<H, P>::new(),
             HyperLogLogVariant::Sparse { data } => {
                 let mut registers = vec![0; 1 << P];
                 for (index, val) in data {
                     registers[index as usize] = val;
                 }
 
-                HyperLogLog::<P> { registers }
+                HyperLogLog::<H, P>::with_registers(registers)
             }
-            HyperLogLogVariant::Full(registers) => HyperLogLog::<P> { registers },
+            HyperLogLogVariant::Full(registers) => HyperLogLog::<H, P>::with_registers(registers),
         }
     }
 }
 
-impl<'a, const P: usize> From<&'a HyperLogLog<P>> for HyperLogLogVariantRef<'a, P> {
-    fn from(hll: &'a HyperLogLog<P>) -> Self {
-        let none_empty_registers = HyperLogLog::<P>::number_registers() - hll.num_empty_registers();
+impl<'a, H: Hasher + Default, const P: usize> From<&'a HyperLogLog<H, P>>
+    for HyperLogLogVariantRef<'a>
+{
+    fn from(hll: &'a HyperLogLog<H, P>) -> Self {
+        let none_empty_registers =
+            HyperLogLog::<H, P>::number_registers() - hll.num_empty_registers();
 
         if none_empty_registers == 0 {
             HyperLogLogVariantRef::Empty
-        } else if none_empty_registers * 3 <= HyperLogLog::<P>::number_registers() {
+        } else if none_empty_registers * 3 <= HyperLogLog::<H, P>::number_registers() {
             // If the number of empty registers is larger enough, we can use sparse serialize to reduce the binary size
             // each register in sparse format will occupy 3 bytes, 2 for register index and 1 for register value.
             let sparse_data: Vec<(u16, u8)> = hll
@@ -60,36 +63,36 @@ impl<'a, const P: usize> From<&'a HyperLogLog<P>> for HyperLogLogVariantRef<'a, 
     }
 }
 
-impl<const P: usize> serde::Serialize for HyperLogLog<P> {
+impl<H: Hasher + Default, const P: usize> serde::Serialize for HyperLogLog<H, P> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        let v: HyperLogLogVariantRef<'_, P> = self.into();
+        let v: HyperLogLogVariantRef<'_> = self.into();
         v.serialize(serializer)
     }
 }
 
-impl<'de, const P: usize> serde::Deserialize<'de> for HyperLogLog<P> {
+impl<'de, H: Hasher + Default, const P: usize> serde::Deserialize<'de> for HyperLogLog<H, P> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        let v = HyperLogLogVariant::<P>::deserialize(deserializer)?;
+        let v = HyperLogLogVariant::deserialize(deserializer)?;
         Ok(v.into())
     }
 }
 
-impl<const P: usize> borsh::BorshSerialize for HyperLogLog<P> {
-    fn serialize<W: core::io::prelude::Write>(&self, writer: &mut W) -> core::io::Result<()> {
-        let v: HyperLogLogVariantRef<'_, P> = self.into();
+impl<H: Hasher + Default, const P: usize> borsh::BorshSerialize for HyperLogLog<H, P> {
+    fn serialize<W: std::io::prelude::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        let v: HyperLogLogVariantRef<'_> = self.into();
         v.serialize(writer)
     }
 }
 
-impl<const P: usize> borsh::BorshDeserialize for HyperLogLog<P> {
-    fn deserialize_reader<R: core::io::prelude::Read>(reader: &mut R) -> core::io::Result<Self> {
-        let v = HyperLogLogVariant::<P>::deserialize_reader(reader)?;
+impl<H: Hasher + Default, const P: usize> borsh::BorshDeserialize for HyperLogLog<H, P> {
+    fn deserialize_reader<R: std::io::prelude::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let v = HyperLogLogVariant::deserialize_reader(reader)?;
         Ok(v.into())
     }
 }
@@ -99,9 +102,11 @@ mod tests {
     use crate::HyperLogLog;
 
     const P: usize = 14;
+    type H = ahash::AHasher;
+
     #[test]
     fn test_serde() {
-        let mut hll = HyperLogLog::<P>::new();
+        let mut hll = HyperLogLog::<H, P>::new();
         json_serde_equal(&hll);
 
         for i in 0..100000 {
@@ -109,7 +114,7 @@ mod tests {
         }
         json_serde_equal(&hll);
 
-        let hll = HyperLogLog::<P>::with_registers(vec![1; 1 << P]);
+        let hll = HyperLogLog::<H, P>::with_registers(vec![1; 1 << P]);
         json_serde_equal(&hll);
     }
 


### PR DESCRIPTION
continue #3 

closes #2 

example to use xxh3 in this crate:

```
 #[test]
    fn test_xxhash_hll() {
        use std::hash::{BuildHasher, Hash};
        #[derive(Default)]
        struct XXH3;
        impl crate::Hasher for XXH3 {
            fn hll_hash<T: Hash>(x: T) -> u64 {
                let builder = xxhash_rust::xxh3::Xxh3Builder::default();
                builder.hash_one(x)
            }
        }

        let mut hll = HyperLogLog::<XXH3, 14>::new();
 	    // ...
    }
```