### PR TITLE
feat: add get registers method

### DIFF
--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -32,8 +32,7 @@ impl<const P: usize> HyperLogLog<P> {
     pub fn new() -> Self {
         assert!(
             (P >= 4) & (P <= 18),
-            "P ({}) must be larger or equal than 4 and smaller or equal than 18",
-            P
+            "P ({P}) must be larger or equal than 4 and smaller or equal than 18",
         );
 
         Self {


### PR DESCRIPTION
1. Rewrote add_hash using `unsafe` and `get_unchecked_mut` to avoid bounds checking and improve performance when updating the register.
2. Added a method `get_registers` to expose an immutable slice of the internal register array.